### PR TITLE
+ fix for issue constructor not matching parent

### DIFF
--- a/src/MailAdminTable.php
+++ b/src/MailAdminTable.php
@@ -10,7 +10,7 @@ class MailAdminTable extends \WP_List_Table
     public $totalItems;
     static private $instance = false;
 
-    private function __construct()
+    public function __construct($args = array())
     {
         parent::__construct([
             'singular' => 'log',


### PR DESCRIPTION
PHP Fatal error: Access level to WpMailCatcher\MailAdminTable::__construct() must be public (as in class WP_List_Table)