### PR TITLE
Bug fix: ensure all log entries are retrieved by ExpiredLogManager::removeExpiredLogs() so that the proper once are deleted.

### DIFF
--- a/src/ExpiredLogManager.php
+++ b/src/ExpiredLogManager.php
@@ -17,7 +17,7 @@ class ExpiredLogManager
         $idsToRemove = [];
         $interval = $timeInterval == null ?  Settings::get('timescale') : $timeInterval;
 
-        foreach (Logs::get() as $log) {
+        foreach (Logs::get( array( 'posts_per_page' => -1 ) ) as $log) {
             if ((time() - $log['timestamp']) >= $interval) {
                 $idsToRemove[] = $log['id'];
             }


### PR DESCRIPTION
Without this, on the most recent 5 entries are retrieved, which generally results in none being deleted.

p.s. Hi James...long time no talk.