### PR TITLE
Improve step 3 of "Contributing" instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 WP Mail Catcher
 </h1>
 
-<p align="center"> 
+<p align="center">
 Backup and save your contact form emails (including Contact Form 7) to your database with this fast, lightweight plugin (under 140kb in size!)
 </p>
 
@@ -84,7 +84,7 @@ Let us know in our [GitHub tracker!](https://github.com/JWardee/wp-mail-catcher/
 Contributions are always welcome, to get started do the following:
 1. Pull the repo and run `composer install`
 2. cd into `build/grunt` and run `npm install`
-3. While inside of `build/grunt` run `grunt` this will watch your scss and js and compile any changes
+3. Still inside `build/grunt` run `npx grunt` (requires `sass` gem). This will build and watch the scss and js
 4. Make sure your code conforms to [PSR-2 standards](http://www.php-fig.org/psr/psr-2/)
 5. Ensure your changes pass all the unit tests
 6. Submit your pull request!


### PR DESCRIPTION
Following the "Contributing" instructions, I bumped in to a couple things:

- The instructions suggest `grunt` command is globally available, which it isn't for me. Since we already depend on `grunt` in `package.json` we can change this instruction to `npx grunt` to use the Grunt we installed in the previous step.
- However it was ran, the Grunt task failed for me. This is because I was missing the `sass` Ruby gem on my (macOS) machine. So I've mentioned this dependency.