### PR TITLE
Fix "pointer" cursor on status indicator

### DIFF
--- a/build/scss/admin.scss
+++ b/build/scss/admin.scss
@@ -53,10 +53,10 @@
     width: 12px;
     border-radius: 100%;
     margin: 5px auto 0 auto;
-    cursor: pointer;
     background-color: #35bc35;
 
     &.-error {
+      cursor: pointer;
       background-color: #fd4f4f;
     }
   }

--- a/src/MailAdminTable.php
+++ b/src/MailAdminTable.php
@@ -156,7 +156,7 @@ class MailAdminTable extends \WP_List_Table
         $this->process_bulk_action();
 
         $overrideParams = array_intersect_key($_REQUEST, Logs::$whitelistedParams);
-    
+
         $this->items = Logs::get(array_merge([
             'paged' => $this->get_pagenum(),
             'post_status' => isset($_GET['post_status']) ? $_GET['post_status'] : 'any',


### PR DESCRIPTION
### Current problem

User gets "pointer" cursor when hovering over the status indicator, even when it's green and does nothing.

It's most common for all the indicators to be green (I never knew about the error behaviour until looking at this) so it feels like something is broken when there is "pointer" cursor on the green indicators but no behaviour.

### Proposed solution

Only apply this "pointer" cursor when in "error" state i.e. when hovering over the element does something.

### Screenshots

**Before:**
![Kapture](https://user-images.githubusercontent.com/247634/183128371-36aacfab-5b2d-41e0-848b-e6d1e72c43b9.gif)

**After:**
![Kapture](https://user-images.githubusercontent.com/247634/183128081-6c25013f-edfb-4864-aba7-968a2d172d57.gif)

---

resolves first item of #149